### PR TITLE
Handle missing google-generativeai

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ This application uses environment variables to securely store your Gemini API ke
 3. Create a new API key
 4. Copy the key and add it to your `.env` file
 
+## Troubleshooting
+
+If the app fails to start or you see an error about `google-generativeai` not
+being installed, make sure all dependencies are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/app.py
+++ b/app.py
@@ -20,11 +20,18 @@ from prompts import (
     ANALYST_TASK_PROMPT_TEMPLATE, ASSOCIATE_REVIEW_PROMPT_TEMPLATE,
     MANAGER_REPORT_PROMPT_TEMPLATE, REVIEWER_PROMPT_TEMPLATE
 )
+# Import feature functions
 from src.ui_helpers import add_download_buttons, reset_session, add_to_conversation, check_api_key
 from src.processing_helpers import parse_associate_tasks, parse_analyst_task_response
-
-# Import feature functions
 from features import setup, manager_planning, data_understanding, analysis_guidance, analysis_execution, final_report
+
+# Alert user immediately if required deps are missing
+if st.session_state.get("genai_import_error", False):
+    st.error(
+        "google-generativeai package is not installed. "
+        "Install dependencies with `pip install -r requirements.txt`."
+    )
+    st.stop()
 
 # --- Page Configuration ---
 st.set_page_config(

--- a/app_combined.py
+++ b/app_combined.py
@@ -10,6 +10,14 @@ import openpyxl # For Excel export
 # import subprocess # Import commented out - for potential future automated install
 from src.utils import configure_genai, get_gemini_response, process_uploaded_file, generate_data_profile_summary, extract_text_from_docx, extract_text_from_pdf
 
+# Alert user immediately if required deps are missing
+if st.session_state.get("genai_import_error", False):
+    st.error(
+        "google-generativeai package is not installed. "
+        "Install dependencies with `pip install -r requirements.txt`."
+    )
+    st.stop()
+
 # --- Page Configuration ---
 st.set_page_config(
     page_title="AI Data Analysis Assistant",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,20 @@
 import os
 import pandas as pd
-import polars as pl # Import Polars
-import google.generativeai as genai
-from dotenv import load_dotenv
+import polars as pl  # Import Polars
+
 import streamlit as st
+
+try:
+    import google.generativeai as genai
+except ModuleNotFoundError:  # pragma: no cover - environment may not have deps
+    genai = None
+    # When running outside Streamlit context we can't use st.error directly
+    # Store a flag so the main app can surface a helpful message
+    st.session_state['genai_import_error'] = (
+        st.session_state.get('genai_import_error', False) or True
+    )
+
+from dotenv import load_dotenv
 import docx
 from PyPDF2 import PdfReader
 import io # Needed for reading uploaded file content with Polars
@@ -28,6 +39,16 @@ def configure_genai(api_key=None):
         # Let the main app handle UI warnings/errors for missing keys during runtime
         # This function might be called before session_state is fully available initially
         print("Warning: No Gemini API key found during configure_genai call.")
+        return False
+    if genai is None:
+        error_message = (
+            "google-generativeai package is not installed. "
+            "Install dependencies with `pip install -r requirements.txt`."
+        )
+        try:
+            st.error(error_message)
+        except Exception:
+            print(error_message)
         return False
     try:
         genai.configure(api_key=key_to_use)
@@ -72,7 +93,14 @@ def get_gemini_response(prompt: str, persona: str = "general", model: str | None
     # Ensure API is configured with the current key for this call
     if not configure_genai(current_api_key):
          # Configuration failed, error likely shown by configure_genai
-         return "Error: Failed to configure Gemini API with the provided key."
+         return "Error: Failed to configure Gemini API with the provided key." \
+                " or missing dependencies."
+
+    if genai is None:
+        return (
+            "Error: google-generativeai package not installed. "
+            "Run `pip install -r requirements.txt`."
+        )
 
     try:
         # Initialize the model - No system_instruction here, it's part of the main 'prompt'


### PR DESCRIPTION
## Summary
- improve import logic for `google.generativeai`
- show dependency error immediately in `app.py` and `app_combined.py`
- document dependency troubleshooting instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
